### PR TITLE
feat: use shadcn/ui buttons for signin and signup

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ClerkProvider, SignInButton, SignUpButton, Show, UserButton } from "@clerk/nextjs";
+import { Button } from "@/components/ui/button";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -32,8 +33,12 @@ export default function RootLayout({
         <ClerkProvider>
           <header className="flex items-center justify-end px-6 py-4">
             <Show when="signed-out">
-              <SignInButton mode="modal" />
-              <SignUpButton mode="modal" />
+              <SignInButton mode="modal">
+                <Button variant="outline">Sign in</Button>
+              </SignInButton>
+              <SignUpButton mode="modal">
+                <Button>Sign up</Button>
+              </SignUpButton>
             </Show>
             <Show when="signed-in">
               <UserButton />


### PR DESCRIPTION
Wraps Clerk's SignInButton and SignUpButton with shadcn/ui Button components to render styled buttons instead of unstyled default tags.

Closes #5

Generated with [Claude Code](https://claude.ai/code)