### PR TITLE
feat: make entire site dark mode

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased dark`}
     >
       <body className="min-h-full flex flex-col">
         <ClerkProvider>


### PR DESCRIPTION
Adds the `dark` class to the `<html>` element in `src/app/layout.tsx` to activate dark mode globally. The project already had dark mode CSS variables and `dark:` Tailwind utilities in place — this is the only change needed.

Closes #6

Generated with [Claude Code](https://claude.ai/code)