### PR TITLE
security: remove committed .env file with leaked credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_ZWFnZXItcG9sbGl3b2ctNTAuY2xlcmsuYWNjb3VudHMuZGV2JA
-CLERK_SECRET_KEY=sk_test_KaXL4iEYBjMRgYBeBhOuBqZHGkJwr2juEMUKzDMGHa
-DATABASE_URL=postgresql://neondb_owner:npg_ki7GgnmAOI1V@ep-nameless-term-anb2n33f-pooler.c-6.us-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require


### PR DESCRIPTION
Removes the .env file that was accidentally committed to the repository, containing PostgreSQL/Neon database credentials. Connection strings are managed via Vercel deployment settings. The .gitignore already excludes .env* files.

Closes #10

Generated with [Claude Code](https://claude.ai/code)